### PR TITLE
docs(readme): add recommended install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Install `textual-dissect` using pip:
 pip install textual-dissect
 ```
 
+> [!NOTE]
+> It is recommended to install `textual-dissect` within your Textual project
+> using pip, rather than as a standalone tool with pipx or uvx.
+> This ensures that the Textual version in this tool aligns with the version
+> in your current project.
+
 ## License
 
 Licensed under the [GNU General Public License v3.0](LICENSE).


### PR DESCRIPTION
Recommend installing `textual-dissect` within your Textual project, rather than as a standalone tool, to ensure the Textual version aligns with your current project.

Closes #10