### PR TITLE
fix: replace lua match in tcss highlights

### DIFF
--- a/src/textual_dissect/app.py
+++ b/src/textual_dissect/app.py
@@ -90,7 +90,7 @@ DOCS_BASE_URL = "https://textual.textualize.io/"
 DOCS_WIDGETS_URL = DOCS_BASE_URL + "widgets/"
 DOCS_CONTAINERS_URL = DOCS_BASE_URL + "api/containers/#textual.containers"
 
-SRC_BASE_URL = f"https://github.com/Textualize/textual/"
+SRC_BASE_URL = "https://github.com/Textualize/textual/"
 SRC_VERSION_PATH = f"blob/v{__version__}/"
 SRC_WIDGETS_URL = SRC_BASE_URL + SRC_VERSION_PATH + "src/textual/widgets/"
 SRC_CONTAINERS_URL = SRC_BASE_URL + SRC_VERSION_PATH + "src/textual/containers.py"

--- a/src/textual_dissect/app.py
+++ b/src/textual_dissect/app.py
@@ -341,9 +341,9 @@ _TCSS_HIGHLIGHT_QUERY = """
 (variable) @type.builtin
 
 ((property_name) @type.definition
-  (#lua-match? @type.definition "^[-][-]"))
+  (#match? @type.definition "^[-][-]"))
 ((plain_value) @type
-  (#lua-match? @type "^[-][-]"))
+  (#match? @type "^[-][-]"))
 
 [
  (string_value)


### PR DESCRIPTION
`lua-match` is specific to tree-sitter in Neovim. Currently these query predicates are ignored so will highlight much more than they should.