### PR TITLE
fix: refine Markdown child widgets

### DIFF
--- a/src/textual_dissect/app.py
+++ b/src/textual_dissect/app.py
@@ -155,7 +155,13 @@ def get_widget_details(
                     and obj.__module__ == module.__name__
                     and obj != class_
                 ):
-                    child_widgets.append(name)
+                    if widget_class == "Markdown" and name in (
+                        "MarkdownViewer",
+                        "MarkdownTableOfContents",
+                    ):
+                        continue
+                    else:
+                        child_widgets.append(name)
 
         base_classes: list[str] = []
         while True:


### PR DESCRIPTION
Refine the `Markdown` child widgets list to exclude `MarkdownViewer` and `MarkdownTableOfContents` also defined in that module.