### PR TITLE
fix: add missing child widgets

### DIFF
--- a/src/textual_dissect/app.py
+++ b/src/textual_dissect/app.py
@@ -147,6 +147,18 @@ def get_widget_details(
         raw_default_css = class_.DEFAULT_CSS
         default_css = dedent(raw_default_css).strip()
 
+        base_classes: list[str] = []
+        current_class = class_
+        while True:
+            base_classes.append(current_class.__name__)
+            for base in current_class.__bases__:
+                if issubclass(base, DOMNode):
+                    current_class = base
+                    break
+            else:
+                break
+        base_classes.reverse()
+
         child_widgets: list[str] = []
         if widget_type != WidgetType.CONTAINER:
             for name, obj in inspect.getmembers(module, inspect.isclass):
@@ -162,18 +174,6 @@ def get_widget_details(
                         continue
                     else:
                         child_widgets.append(name)
-
-        base_classes: list[str] = []
-        while True:
-            base_classes.append(class_.__name__)
-            for base in class_.__bases__:
-                if issubclass(base, DOMNode):
-                    class_ = base
-                    break
-            else:
-                break
-
-        base_classes.reverse()
 
         _WIDGET_DETAILS_CACHE[widget_class] = WidgetDetails(
             docs_url=docs_url,

--- a/src/textual_dissect/app.py
+++ b/src/textual_dissect/app.py
@@ -174,6 +174,16 @@ def get_widget_details(
                         continue
                     else:
                         child_widgets.append(name)
+            # Currently this list is missing the child widgets imported from
+            # other modules. There might be a smarter way of adding these, but
+            # for now just hard code the missing widgets.
+            if widget_class == "ListView":
+                child_widgets.append("ListItem")
+            elif widget_class == "RadioSet":
+                child_widgets.append("RadioButton")
+            elif widget_class == "TabbedContent":
+                child_widgets.append("ContentSwitcher")
+            child_widgets.sort()
 
         _WIDGET_DETAILS_CACHE[widget_class] = WidgetDetails(
             docs_url=docs_url,


### PR DESCRIPTION
Currently the 'Child Widgets' list is missing the widgets imported from other modules. There might be a smarter way of adding these, but for now just hard code the missing widgets.